### PR TITLE
feat: add React Native player manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,9 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Lock files
+package-lock.json
+
+# Expo files
+.expo/

--- a/App.js
+++ b/App.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { SafeAreaView, StyleSheet } from 'react-native';
+import PlayerForm from './components/PlayerForm';
+
+export default function App() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <PlayerForm />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: '#fff'
+  }
+});

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# GLX-COORDS
+
+Aplicación React Native para gestionar jugadores de Galaxy Life.
+
+## Características
+- Registrar jugadores con alianza, nivel y coordenadas de hasta 12 planetas.
+- Buscar, actualizar y eliminar jugadores por nombre.
+- Almacenamiento local utilizando `AsyncStorage`.
+
+## Requisitos
+- [Node.js](https://nodejs.org/)
+- [Expo](https://expo.dev/)
+
+## Instalación
+```
+npm install
+```
+
+## Ejecución
+- Web: `npm run web`
+- Android: `npm run android`
+- iOS: `npm run ios`
+
+## Pruebas
+```
+npm test
+```

--- a/components/PlayerForm.js
+++ b/components/PlayerForm.js
@@ -1,0 +1,178 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  Button,
+  ScrollView,
+  StyleSheet,
+  Alert
+} from 'react-native';
+import {
+  savePlayer,
+  getPlayerByName,
+  updatePlayer,
+  deletePlayer
+} from '../utils/storage';
+
+const planetLabels = ['PP','Col1','Col2','Col3','Col4','Col5','Col6','Col7','Col8','Col9','Col10','Col11'];
+
+const emptyPlanet = { coord: '', star: '' };
+
+export default function PlayerForm() {
+  const [name, setName] = useState('');
+  const [alliance, setAlliance] = useState('');
+  const [level, setLevel] = useState('');
+  const [planets, setPlanets] = useState(Array(planetLabels.length).fill(null).map(() => ({ ...emptyPlanet })));
+
+  const handlePlanetChange = (index, field, value) => {
+    const updated = planets.map((p, i) => (i === index ? { ...p, [field]: value } : p));
+    setPlanets(updated);
+  };
+
+  const clearForm = () => {
+    setName('');
+    setAlliance('');
+    setLevel('');
+    setPlanets(Array(planetLabels.length).fill(null).map(() => ({ ...emptyPlanet })));
+  };
+
+  const handleSave = async () => {
+    try {
+      await savePlayer({ name, alliance, level, planets });
+      Alert.alert('Éxito', 'Registro guardado.');
+    } catch (e) {
+      Alert.alert('Error', e.message);
+    }
+  };
+
+  const handleSearch = async () => {
+    try {
+      const player = await getPlayerByName(name);
+      if (player) {
+        setAlliance(player.alliance);
+        setLevel(player.level);
+        setPlanets(player.planets);
+        Alert.alert('Información', 'Registro encontrado.');
+      } else {
+        Alert.alert('Información', 'No se encontró un registro con ese nombre.');
+      }
+    } catch (e) {
+      Alert.alert('Error', e.message);
+    }
+  };
+
+  const handleUpdate = async () => {
+    try {
+      await updatePlayer({ name, alliance, level, planets });
+      Alert.alert('Éxito', 'Datos actualizados.');
+    } catch (e) {
+      Alert.alert('Error', e.message);
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deletePlayer(name);
+      clearForm();
+      Alert.alert('Éxito', 'Registro eliminado.');
+    } catch (e) {
+      Alert.alert('Error', e.message);
+    }
+  };
+
+  return (
+    <ScrollView>
+      <Text style={styles.title}>Gestión de Jugadores</Text>
+      <View style={styles.fieldRow}>
+        <Text style={styles.label}>Nombre:</Text>
+        <TextInput style={styles.input} value={name} onChangeText={setName} />
+      </View>
+      <View style={styles.fieldRow}>
+        <Text style={styles.label}>Alianza:</Text>
+        <TextInput style={styles.input} value={alliance} onChangeText={setAlliance} />
+      </View>
+      <View style={styles.fieldRow}>
+        <Text style={styles.label}>Nivel:</Text>
+        <TextInput style={styles.input} value={level} onChangeText={setLevel} keyboardType="numeric" />
+      </View>
+
+      {planets.map((planet, index) => (
+        <View key={index} style={styles.planetContainer}>
+          <Text style={styles.planetLabel}>{planetLabels[index]}:</Text>
+          <TextInput
+            style={styles.coordInput}
+            placeholder="Coordenada"
+            value={planet.coord}
+            onChangeText={(text) => handlePlanetChange(index, 'coord', text)}
+          />
+          <TextInput
+            style={styles.starInput}
+            placeholder="⭐"
+            value={planet.star}
+            onChangeText={(text) => handlePlanetChange(index, 'star', text)}
+            keyboardType="numeric"
+          />
+        </View>
+      ))}
+
+      <View style={styles.buttonRow}>
+        <Button title="Buscar" onPress={handleSearch} />
+        <Button title="Guardar" onPress={handleSave} />
+        <Button title="Actualizar" onPress={handleUpdate} />
+        <Button title="Eliminar" onPress={handleDelete} />
+        <Button title="Limpiar" onPress={clearForm} />
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  title: {
+    fontSize: 24,
+    marginBottom: 20,
+    textAlign: 'center'
+  },
+  fieldRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 10
+  },
+  label: {
+    width: 80,
+    fontWeight: 'bold'
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 5
+  },
+  planetContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8
+  },
+  planetLabel: {
+    width: 60
+  },
+  coordInput: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 5,
+    marginRight: 5
+  },
+  starInput: {
+    width: 40,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 5
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 20,
+    flexWrap: 'wrap'
+  }
+});

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "glx-coords",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "@expo/metro-runtime": "~3.1.3",
+    "@react-native-async-storage/async-storage": "^1.21.0",
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.73.0",
+    "react-native-web": "~0.19.6"
+  }
+}

--- a/utils/storage.js
+++ b/utils/storage.js
@@ -1,0 +1,42 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = 'players';
+
+export async function getPlayers() {
+  const json = await AsyncStorage.getItem(STORAGE_KEY);
+  return json ? JSON.parse(json) : [];
+}
+
+export async function savePlayer(player) {
+  const players = await getPlayers();
+  const exists = players.some(p => p.name.toLowerCase() === player.name.toLowerCase());
+  if (exists) {
+    throw new Error('El nombre ingresado ya existe.');
+  }
+  players.push(player);
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(players));
+}
+
+export async function getPlayerByName(name) {
+  const players = await getPlayers();
+  return players.find(p => p.name.toLowerCase() === name.toLowerCase());
+}
+
+export async function updatePlayer(player) {
+  const players = await getPlayers();
+  const index = players.findIndex(p => p.name.toLowerCase() === player.name.toLowerCase());
+  if (index === -1) {
+    throw new Error('No se encontró un registro con ese nombre.');
+  }
+  players[index] = player;
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(players));
+}
+
+export async function deletePlayer(name) {
+  const players = await getPlayers();
+  const filtered = players.filter(p => p.name.toLowerCase() !== name.toLowerCase());
+  if (filtered.length === players.length) {
+    throw new Error('No se encontró un registro con ese nombre.');
+  }
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+}


### PR DESCRIPTION
## Summary
- scaffold Expo-based React Native app to manage Galaxy Life war players
- provide form to add, search, update, and delete players with planet coordinates
- persist player data locally using AsyncStorage
- pin React and React DOM to 18.2.0 to resolve npm install dependency conflicts
- remove package-lock.json and update .gitignore to prevent future commits
- include web runtime dependencies and ignore Expo cache directory
- register Expo root component for proper web rendering

## Testing
- `npm install`
- `npm test`
- `npm run web` *(fails: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b26626a08324a01839a74701bc11